### PR TITLE
Move to drawing fstar individually

### DIFF
--- a/src/draw-fstar.cpp
+++ b/src/draw-fstar.cpp
@@ -2,22 +2,26 @@
 
 arma::mat draw_fstar(const arma::mat& f, const arma::vec& theta,
                      const arma::vec& theta_star, const arma::mat& S00,
-                     const arma::mat& S11, const double sf,
-                     const double ell) {
+                     const double sf, const double ell) {
+    int n = f.n_rows;
     int m = f.n_cols;
     int N = theta_star.n_elem;
     arma::mat result(N, m);
-    arma::vec fj(N);
-    arma::vec fmu(N);
-    arma::mat S01  = K(theta,      theta_star, sf, ell);
-    // We use S10 * S00.i() in each loop iteration, so we store it now
-    arma::mat S10_S00i = S01.t() * S00.i();
-    arma::mat S = S11 - ( S10_S00i * S01 );
-    S.diag() += 0.001;
-    for ( arma::uword j = 0; j < m; ++j ) {
-        fj = f.col(j);
-        fmu = S10_S00i * fj;
-        result.col(j) = rmvnorm(1, fmu, S).t();
+    arma::vec fj(n);
+    arma::mat S00i = S00.i();
+    arma::mat S01(n, 1);
+    arma::mat S10_S00i(1, n);
+    arma::vec th_star(1);
+    for ( arma::uword i = 0; i < N; ++i ) {
+        th_star[0] = theta_star[i];
+        S01        = K(theta, th_star, sf, ell);
+        S10_S00i   = S01.t() * S00i;
+        double S   = (sf * sf) - arma::as_scalar(S10_S00i * S01);
+        for ( arma::uword j = 0; j < m; ++j ) {
+            fj = f.col(j);
+            double fmu = arma::as_scalar(S10_S00i * fj);
+            result(i, j) = R::rnorm(fmu, S);
+        }
     }
     return result;
 }

--- a/src/gpirt.h
+++ b/src/gpirt.h
@@ -11,8 +11,7 @@ arma::mat draw_f(const arma::mat& f, const arma::mat& y, const arma::mat& S);
 // Function to draw fstar
 arma::mat draw_fstar(const arma::mat& f, const arma::vec& theta,
                      const arma::vec& theta_star, const arma::mat& S00,
-                     const arma::mat& S11, const double sf,
-                     const double ell);
+                     const double sf, const double ell);
 
 // Function to draw theta
 arma::vec draw_theta(const int n, const arma::vec& theta_star,

--- a/src/gpirtMCMC.cpp
+++ b/src/gpirtMCMC.cpp
@@ -24,8 +24,6 @@ Rcpp::List gpirtMCMC(const arma::mat& y, const int sample_iterations,
         theta0_prior[i] = d_truncnorm(theta_star[i], 0, 1, R_NegInf, 0, 1);
         thetai_prior[i] = R::dnorm(theta_star[i], 0, 1, 1);
     }
-    // K(theta_star, theta_star) also doesn't change between iterations
-    arma::mat S11 = K(theta_star, theta_star, sf, ell);
     // Setup results storage
     arma::mat theta_draws(sample_iterations, n);
     arma::cube f_draws(n, m, sample_iterations);
@@ -42,7 +40,7 @@ Rcpp::List gpirtMCMC(const arma::mat& y, const int sample_iterations,
         Rcpp::checkUserInterrupt();
         // Draw new parameter values
         f = draw_f(f, y, S);
-        f_star = draw_fstar(f, theta, theta_star, S, S11, sf, ell);
+        f_star = draw_fstar(f, theta, theta_star, S, sf, ell);
         theta = draw_theta(n, theta_star, y, theta0_prior, thetai_prior, f_star);
         S = K(theta, theta, sf, ell);
         S.diag() += 0.001;


### PR DESCRIPTION
On my first stab at the sampler, I just drew the predicted values of
the f_j for all possible theta values at once. However, of course it
is much faster to draw a predicted value for f_j at *each* of the
possible values of theta individually, per our Slack discussion. This
update does that, and on a toy dataset with 100 respondents and 100
items, led to a 6x speedup.

Closes #10 